### PR TITLE
Allows user defined color

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add dependency to pubspec.yaml
 ```
 dependencies:
   ...
-  loading: ^1.0.1
+  loading: ^1.0.2
 ```
 Run in your terminal
 
@@ -27,7 +27,7 @@ flutter packages get
       body: Container(
         color: Colors.lightBlue,
         child: Center(
-          child: Loading(indicator: BallPulseIndicator(), size: 100.0),
+          child: Loading(indicator: BallPulseIndicator(), size: 100.0, color: Colors.redAccent),
         ),
       ),
 ```

--- a/loading/CHANGELOG.md
+++ b/loading/CHANGELOG.md
@@ -2,5 +2,6 @@
 ## [0.0.2] - change class name.
 ## [1.0.0] - work out.
 ## [1.0.1] - fix gif error.
+## [1.0.2] - allows user defined color.
 
 * TODO: add more indicator.

--- a/loading/README.md
+++ b/loading/README.md
@@ -11,7 +11,7 @@ Add dependency to pubspec.yaml
 ```
 dependencies:
   ...
-  loading: ^1.0.1
+  loading: ^1.0.2
 ```
 Run in your terminal
 
@@ -27,7 +27,7 @@ flutter packages get
       body: Container(
         color: Colors.lightBlue,
         child: Center(
-          child: Loading(indicator: BallPulseIndicator(), size: 100.0),
+          child: Loading(indicator: BallPulseIndicator(), size: 100.0, color: Colors.redAccent),
         ),
       ),
 ```

--- a/loading/lib/loading.dart
+++ b/loading/lib/loading.dart
@@ -4,9 +4,10 @@ import 'package:loading/indicator/ball_scale_indicator.dart';
 
 class Loading extends StatefulWidget {
   Indicator indicator;
+  Color color;
   double size;
 
-  Loading({this.indicator,  this.size=50.0}) {
+  Loading({this.indicator,  this.size=50.0, this.color}) {
     if (indicator == null) {
       indicator = BallScaleIndicator();
     } else {
@@ -16,15 +17,16 @@ class Loading extends StatefulWidget {
 
   @override
   State<StatefulWidget> createState() {
-    return LoadingState(indicator, size);
+    return LoadingState(indicator, size, color);
   }
 }
 
 class LoadingState extends State<Loading> with TickerProviderStateMixin {
   Indicator indicator;
   double size;
+  Color color;
 
-  LoadingState(this.indicator, this.size);
+  LoadingState(this.indicator, this.size, this.color);
 
   @override
   void initState() {
@@ -42,7 +44,7 @@ class LoadingState extends State<Loading> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     return CustomPaint(
-      painter: _Painter(indicator),
+      painter: _Painter(indicator, color),
       size: Size.square(size),
     );
   }
@@ -50,17 +52,18 @@ class LoadingState extends State<Loading> with TickerProviderStateMixin {
 
 class _Painter extends CustomPainter {
   Indicator indicator;
+  Color color;
 
-  _Painter(this.indicator);
-
-  final defaultPaint = Paint()
-    ..strokeCap = StrokeCap.butt
-    ..style = PaintingStyle.fill
-    ..color = Color.fromARGB(255, 255, 255, 255)
-    ..isAntiAlias = true;
+  _Painter(this.indicator, this.color);
 
   @override
   void paint(Canvas canvas, Size size) {
+    final defaultPaint = Paint()
+      ..strokeCap = StrokeCap.butt
+      ..style = PaintingStyle.fill
+      ..color = color == null ? Color.fromARGB(255, 255, 255, 255) : color
+      ..isAntiAlias = true;
+
     indicator.paint(canvas, defaultPaint, size);
   }
 


### PR DESCRIPTION
Added the `Color` property to the `Loading` widget to allow users to set their own desired color. Default color is set to `white` when user does not set their own color.