### PR TITLE
Fixed AnimationController.stop() called after AnimationController.dispose()

### DIFF
--- a/loading/lib/indicator/ball_beat_indicator.dart
+++ b/loading/lib/indicator/ball_beat_indicator.dart
@@ -52,7 +52,7 @@ class BallBeatIndicator extends Indicator {
   startAnims(List<AnimationController> controllers) {
     for (var i = 0; i < controllers.length; i++) {
       Future.delayed(Duration(milliseconds: delays[i]), () {
-        startAnim(controllers[i]);
+        if (context.mounted) startAnim(controllers[i]);
       });
     }
   }

--- a/loading/lib/indicator/ball_grid_pulse_indicator.dart
+++ b/loading/lib/indicator/ball_grid_pulse_indicator.dart
@@ -51,7 +51,7 @@ class BallGridPulseIndicator extends Indicator {
     var delays = [-60, 250, -170, 480, 310, 30, 460, 780, 450];
     for (var i = 0; i < controllers.length; i++) {
       Future.delayed(Duration(milliseconds: delays[i]), () {
-        controllers[i].repeat(reverse: true);
+        if (context.mounted) controllers[i].repeat(reverse: true);
       });
     }
   }

--- a/loading/lib/indicator/ball_pulse_indicator.dart
+++ b/loading/lib/indicator/ball_pulse_indicator.dart
@@ -52,7 +52,7 @@ class BallPulseIndicator extends Indicator {
   startAnims(List<AnimationController> controllers) async {
     for (var i = 0; i < controllers.length; i++) {
       await Future.delayed(Duration(milliseconds: 120), () {
-        startAnim(controllers[i]);
+        if (context.mounted) startAnim(controllers[i]);
       });
     }
   }

--- a/loading/lib/indicator/ball_scale_multiple_indicator.dart
+++ b/loading/lib/indicator/ball_scale_multiple_indicator.dart
@@ -39,7 +39,7 @@ class BallScaleMultipleIndicator extends Indicator {
   startAnims(List<AnimationController> controllers) async {
     for (var i = 0; i < controllers.length; i++) {
       await Future.delayed(Duration(milliseconds: delays[i]), () {
-        controllers[i].repeat();
+        if (context.mounted) controllers[i].repeat();
       });
     }
   }

--- a/loading/lib/indicator/ball_spin_fade_loader_indicator.dart
+++ b/loading/lib/indicator/ball_spin_fade_loader_indicator.dart
@@ -46,7 +46,7 @@ class BallSpinFadeLoaderIndicator extends Indicator {
     var delays = [0, 120, 240, 360, 480, 600, 720, 780, 840];
     for (var i = 0; i < controllers.length; i++) {
       Future.delayed(Duration(milliseconds: delays[i]), () {
-        controllers[i].repeat(reverse: true);
+        if (context.mounted) controllers[i].repeat(reverse: true);
       });
     }
   }

--- a/loading/lib/indicator/line_scale_indicator.dart
+++ b/loading/lib/indicator/line_scale_indicator.dart
@@ -40,7 +40,7 @@ class LineScaleIndicator extends Indicator {
     var delays = [100, 200, 300, 400, 500];
     for (var i = 0; i < controllers.length; i++) {
       Future.delayed(Duration(milliseconds: delays[i]), () {
-        controllers[i].repeat(reverse: true);
+        if (context.mounted) controllers[i].repeat(reverse: true);
       });
     }
   }

--- a/loading/lib/indicator/line_scale_party_indicator.dart
+++ b/loading/lib/indicator/line_scale_party_indicator.dart
@@ -42,7 +42,7 @@ class LineScalePartyIndicator extends Indicator {
     var delays = [770, 290, 280, 740];
     for (var i = 0; i < controllers.length; i++) {
       Future.delayed(Duration(milliseconds: delays[i]), () {
-        controllers[i].repeat(reverse: true);
+        if (context.mounted) controllers[i].repeat(reverse: true);
       });
     }
   }

--- a/loading/lib/indicator/line_scale_pulse_out_indicator.dart
+++ b/loading/lib/indicator/line_scale_pulse_out_indicator.dart
@@ -40,7 +40,7 @@ class LineScalePulseOutIndicator extends Indicator {
     var delays = [500,250,0,250,500];
     for (var i = 0; i < controllers.length; i++) {
       Future.delayed(Duration(milliseconds: delays[i]), () {
-        controllers[i].repeat(reverse: true);
+        if (context.mounted) controllers[i].repeat(reverse: true);
       });
     }
   }


### PR DESCRIPTION
Fixed the open issue AnimationController.animateWith() called after AnimationController.dispose()
by simply checking that context is mounted before performing reverse
